### PR TITLE
Implement chat UI components and Zustand stores

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "next": "^15.0.0",
     "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "typescript": "^5.0.0",
     "tailwindcss": "^3.4.0",
     "zustand": "^4.4.0",
@@ -28,6 +29,7 @@
     "prettier": "^3.0.0",
     "jest": "^29.7.0",
     "@testing-library/react": "^13.4.0",
-    "cypress": "^13.0.0"
+    "cypress": "^13.0.0",
+    "autoprefixer": "^10.0.0"
   }
 }

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -1,0 +1,80 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Menu, Settings, Send } from "lucide-react";
+import ChatWindow from "@/components/chat/ChatWindow";
+import VoiceInput from "@/components/chat/VoiceInput";
+import { useChatStore } from "@/store/chatStore";
+
+const formatTime = (seconds: number) => {
+  const m = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, "0");
+  const s = Math.floor(seconds % 60)
+    .toString()
+    .padStart(2, "0");
+  return `${m}:${s}`;
+};
+
+export default function ChatPage() {
+  const [input, setInput] = useState("");
+  const addMessage = useChatStore((state) => state.addMessage);
+  const startSession = useChatStore((state) => state.startSession);
+  const updateTimer = useChatStore((state) => state.updateTimer);
+  const timeRemaining = useChatStore((state) => state.timeRemaining);
+
+  useEffect(() => {
+    startSession();
+  }, [startSession]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const current = useChatStore.getState().timeRemaining;
+      if (current > 0) {
+        updateTimer(current - 1);
+      }
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [updateTimer]);
+
+  const handleSend = () => {
+    if (!input.trim()) return;
+    addMessage({
+      id: Date.now().toString(),
+      sessionId: useChatStore.getState().sessionId ?? "",
+      type: "user",
+      content: input,
+      timestamp: new Date(),
+    });
+    setInput("");
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="flex items-center justify-between border-b p-4">
+        <Menu />
+        <h1 className="text-lg font-bold">Talk with AI</h1>
+        <Settings />
+      </header>
+      <div className="border-b p-2 text-sm">
+        🕐 残り時間: {formatTime(timeRemaining)}
+      </div>
+      <ChatWindow />
+      <div className="flex items-center border-t p-2">
+        <VoiceInput />
+        <input
+          className="mx-2 flex-1 rounded border px-2 py-1 text-sm"
+          placeholder="入力..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <button
+          onClick={handleSend}
+          className="text-blue-500"
+          aria-label="send"
+        >
+          <Send size={20} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/ChatWindow.tsx
+++ b/frontend/src/components/chat/ChatWindow.tsx
@@ -1,0 +1,27 @@
+"use client";
+import MessageBubble from "./MessageBubble";
+import { useChatStore } from "@/store/chatStore";
+
+import { useEffect, useRef } from "react";
+
+const ChatWindow = () => {
+  const messages = useChatStore((state) => state.messages);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [messages]);
+
+  return (
+    <div ref={containerRef} className="flex-1 space-y-4 overflow-y-auto p-4">
+      {messages.map((msg) => (
+        <MessageBubble key={msg.id} message={msg} />
+      ))}
+    </div>
+  );
+};
+
+export default ChatWindow;

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { FC } from "react";
+import type { Message } from "@/store/chatStore";
+
+interface Props {
+  message: Message;
+}
+
+const MessageBubble: FC<Props> = ({ message }) => {
+  const isUser = message.type === "user";
+  return (
+    <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
+      {!isUser && <span className="mr-2">👩‍💻</span>}
+      <div
+        className={`max-w-xs rounded-lg px-3 py-2 text-sm ${
+          isUser ? "bg-blue-500 text-white" : "bg-gray-100"
+        }`}
+      >
+        <p>{message.content}</p>
+        <div className="mt-1 text-right text-[10px] opacity-70">
+          {message.timestamp.toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+          })}
+        </div>
+      </div>
+      {isUser && <span className="ml-2">👤</span>}
+    </div>
+  );
+};
+
+export default MessageBubble;

--- a/frontend/src/components/chat/VoiceInput.tsx
+++ b/frontend/src/components/chat/VoiceInput.tsx
@@ -1,0 +1,20 @@
+'use client';
+import { Mic } from 'lucide-react';
+
+interface VoiceInputProps {
+  onVoiceInput?: () => void;
+}
+
+const VoiceInput = ({ onVoiceInput }: VoiceInputProps) => {
+  return (
+    <button
+      onClick={onVoiceInput}
+      className="rounded p-2 text-blue-500 hover:text-blue-700"
+      aria-label="voice input"
+    >
+      <Mic size={20} />
+    </button>
+  );
+};
+
+export default VoiceInput;

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,0 +1,58 @@
+'use client';
+import { create } from 'zustand';
+
+interface User {
+  id: string;
+  email: string;
+  name: string;
+}
+
+interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+interface RegisterData {
+  email: string;
+  password: string;
+  name: string;
+}
+
+interface UserProfile {
+  name: string;
+  email: string;
+}
+
+interface AuthState {
+  user: User | null;
+  isAuthenticated: boolean;
+  token: string | null;
+
+  login: (credentials: LoginCredentials) => Promise<void>;
+  logout: () => void;
+  register: (userData: RegisterData) => Promise<void>;
+  updateProfile: (profile: Partial<UserProfile>) => Promise<void>;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  user: null,
+  isAuthenticated: false,
+  token: null,
+  login: async (credentials) => {
+    set({
+      user: { id: '1', email: credentials.email, name: 'User' },
+      isAuthenticated: true,
+      token: 'dummy-token',
+    });
+  },
+  logout: () => set({ user: null, isAuthenticated: false, token: null }),
+  register: async (userData) => {
+    set({
+      user: { id: '1', email: userData.email, name: userData.name },
+      isAuthenticated: true,
+      token: 'dummy-token',
+    });
+  },
+  updateProfile: async (profile) =>
+    set((state) => ({ user: state.user ? { ...state.user, ...profile } : null })),
+}));

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -1,0 +1,44 @@
+'use client';
+import { create } from 'zustand';
+
+export interface Message {
+  id: string;
+  sessionId: string;
+  type: 'user' | 'ai';
+  content: string;
+  timestamp: Date;
+  metadata?: {
+    confidence?: number;
+    topic?: string;
+    codeSnippet?: boolean;
+  };
+}
+
+interface ChatState {
+  messages: Message[];
+  isLoading: boolean;
+  sessionId: string | null;
+  timeRemaining: number;
+  currentTopic: string;
+
+  addMessage: (message: Message) => void;
+  startSession: () => void;
+  endSession: () => void;
+  updateTimer: (seconds: number) => void;
+  setCurrentTopic: (topic: string) => void;
+}
+
+export const useChatStore = create<ChatState>((set) => ({
+  messages: [],
+  isLoading: false,
+  sessionId: null,
+  timeRemaining: 0,
+  currentTopic: '',
+  addMessage: (message) =>
+    set((state) => ({ messages: [...state.messages, message] })),
+  startSession: () =>
+    set(() => ({ sessionId: `${Date.now()}`, messages: [], timeRemaining: 30 * 60 })),
+  endSession: () => set(() => ({ sessionId: null, timeRemaining: 0 })),
+  updateTimer: (seconds) => set(() => ({ timeRemaining: seconds })),
+  setCurrentTopic: (topic) => set(() => ({ currentTopic: topic })),
+}));


### PR DESCRIPTION
## Summary
- scaffold chat page following the wireframe
- add reusable chat components (ChatWindow, MessageBubble, VoiceInput)
- setup Zustand stores for chat and authentication
- add missing `react-dom` and `autoprefixer` dependencies
- improve chat components: shared Message type, auto-scroll, and timer countdown

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*
- `npm run lint` *(interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_685181502740832392c1a113d5836d87